### PR TITLE
add plantuml support

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -10,7 +10,6 @@ export default defineUserConfig({
   shouldPrefetch: false,
 
   extendsMarkdown: (md) => {
-    md.set({ breaks: true });
     md.use(plantuml);
   },
 

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -1,5 +1,6 @@
 import { defineUserConfig } from "vuepress";
 import theme from "./theme";
+import plantuml from "markdown-it-plantuml";
 
 export default defineUserConfig({
   lang: "zh-CN",
@@ -7,6 +8,11 @@ export default defineUserConfig({
   description: "This is yuanzhixiang's blog",
   theme,
   shouldPrefetch: false,
+
+  extendsMarkdown: (md) => {
+    md.set({ breaks: true });
+    md.use(plantuml);
+  },
 
   plugins: [
     // todo wait https://support.algolia.com/hc/en-us/requests/538272 finish, then config search

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -1,6 +1,6 @@
 import { defineUserConfig } from "vuepress";
 import theme from "./theme";
-import plantuml from "markdown-it-plantuml";
+import plantuml from "markdown-it-textual-uml"; 
 
 export default defineUserConfig({
   lang: "zh-CN",

--- a/docs/test.md
+++ b/docs/test.md
@@ -11,7 +11,7 @@ test
 
 2
 
-```
+```plantuml
 @startuml
 用户 -> 认证中心: 登录操作
 认证中心 -> 缓存: 存放(key=token+ip,value=token)token

--- a/docs/test.md
+++ b/docs/test.md
@@ -10,3 +10,27 @@ test
 ## 2
 
 2
+
+```
+@startuml
+用户 -> 认证中心: 登录操作
+认证中心 -> 缓存: 存放(key=token+ip,value=token)token
+
+用户 <- 认证中心 : 认证成功返回token
+用户 -> 认证中心: 下次访问头部携带token认证
+认证中心 <- 缓存: key=token+ip获取token
+其他服务 <- 认证中心: 存在且校验成功则跳转到用户请求的其他服务
+其他服务 -> 用户: 信息
+@enduml
+```
+
+@startuml
+用户 -> 认证中心: 登录操作
+认证中心 -> 缓存: 存放(key=token+ip,value=token)token
+
+用户 <- 认证中心 : 认证成功返回token
+用户 -> 认证中心: 下次访问头部携带token认证
+认证中心 <- 缓存: key=token+ip获取token
+其他服务 <- 认证中心: 存在且校验成功则跳转到用户请求的其他服务
+其他服务 -> 用户: 信息
+@enduml

--- a/docs/test.md
+++ b/docs/test.md
@@ -1,15 +1,8 @@
 # test
 
-test
+## uml
 
-
-## 1
-
-1
-
-## 2
-
-2
+### plantuml
 
 ```plantuml
 @startuml
@@ -24,6 +17,41 @@ test
 @enduml
 ```
 
+### dot
+
+```dot
+digraph example1 {
+    1 -> 2 -> { 4, 5 };
+    1 -> 3 -> { 6, 7 };
+}
+```
+
+### ditaa
+
+```ditaa
++--------+   +-------+    +-------+
+|        +---+ ditaa +--> |       |
+|  Text  |   +-------+    |diagram|
+|Document|   |!magic!|    |       |
+|     {d}|   |       |    |       |
++---+----+   +-------+    +-------+
+  :                         ^
+  |       Lots of work      |
+  +-------------------------+
+```
+
+### mermaid
+
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```
+
+### plain
+
 @startuml
 用户 -> 认证中心: 登录操作
 认证中心 -> 缓存: 存放(key=token+ip,value=token)token
@@ -34,3 +62,6 @@ test
 其他服务 <- 认证中心: 存在且校验成功则跳转到用户请求的其他服务
 其他服务 -> 用户: 信息
 @enduml
+
+<!-- <script src="mermaid.min.js"></script> -->
+<!-- <script>mermaid.initialize({startOnLoad:true});</script> -->

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "devDependencies": {
     "@vuepress/client": "2.0.0-beta.60",
-    "markdown-it-plantuml": "^1.4.1",
+    "markdown-it-textual-uml": "^0.12.0",
     "vue": "^3.2.45",
     "vuepress": "2.0.0-beta.60",
     "vuepress-theme-hope": "2.0.0-beta.165"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "devDependencies": {
     "@vuepress/client": "2.0.0-beta.60",
+    "markdown-it-plantuml": "^1.4.1",
     "vue": "^3.2.45",
     "vuepress": "2.0.0-beta.60",
     "vuepress-theme-hope": "2.0.0-beta.165"


### PR DESCRIPTION
#12 

- [x] 修改 openMarker 为 ```plantuml
- [ ] 弄明白渲染是编译 markdown 时进行的还是浏览器运行时进行的
- [ ] 支持多种绘图数据源
    - [配置 mermaid 进入 vuepress](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/)

# 参考文章

- [Vuepress 增加 PlantUML 支持](https://wkii.github.io/Tech/vuepress-add-plantUML-plugin.html)
- [markdown-it-plantuml npm repository](https://www.npmjs.com/package/markdown-it-plantuml)
- [markdown-it-textual-uml](https://www.npmjs.com/package/markdown-it-textual-uml)